### PR TITLE
feat: add events page

### DIFF
--- a/web/app/themes/awasqa/style.css
+++ b/web/app/themes/awasqa/style.css
@@ -122,6 +122,20 @@ h6::after {
 .wp-block-categories a:focus, .wp-block-categories a:hover {
   background-color: var(--color-orange);
         }
+.wp-block-categories a.active {
+  background-color: var(--color-orange);
+  border-radius: 0.25rem;
+  color: var(--color-green);
+  display: inline-block;
+  font-size: 0.875rem;
+  font-weight: bold;
+  padding: 0.5rem 1rem;
+  text-decoration: none;
+  text-transform: uppercase;
+    }
+.wp-block-categories a.active:focus, .wp-block-categories a.active:hover {
+  background-color: var(--color-green-lightest);
+        }
 .wp-block-post-featured-image {
     margin-bottom: 0.875rem;
 }

--- a/web/app/themes/awasqa/styles/buttons.css
+++ b/web/app/themes/awasqa/styles/buttons.css
@@ -15,6 +15,22 @@
         }
     }
 
+    --button-active {
+        background-color: var(--color-orange);
+        border-radius: 0.25rem;
+        color: var(--color-green);
+        display: inline-block;
+        font-size: 0.875rem;
+        font-weight: bold;
+        padding: 0.5rem 1rem;
+        text-decoration: none;
+        text-transform: uppercase;
+
+        &:focus, &:hover {
+            background-color: var(--color-green-lightest);
+        }
+    }
+
     --button-inverse {
         border: 1px solid var(--color-green);
         background-color: var(--color-green);

--- a/web/app/themes/awasqa/styles/wp.css
+++ b/web/app/themes/awasqa/styles/wp.css
@@ -16,6 +16,10 @@
     a {
         @apply --button-default;
     }
+
+    a.active {
+        @apply --button-active;
+    }
 }
 
 .wp-block-post-featured-image {


### PR DESCRIPTION
Adds an events page layout, with filtering by date and filtering by country.

Complex parts are:

1. Getting / Using the translated versions of slugs (e.g. pais=mexico instead of country=mexico)
2. Ensuring the event date filtered blocks work.